### PR TITLE
[types] fix order of V/K types in top-level open() fn

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'lmdb-store' {
-	export function open<K extends Key = Key, V = any>(path: string, options: RootDatabaseOptions): RootDatabase<V, K>
-	export function open<K extends Key = Key, V = any>(options: RootDatabaseOptionsWithPath): RootDatabase<V, K>
+	export function open<V = any, K extends Key = Key>(path: string, options: RootDatabaseOptions): RootDatabase<V, K>
+	export function open<V = any, K extends Key = Key>(options: RootDatabaseOptionsWithPath): RootDatabase<V, K>
 
 	class Database<V = any, K extends Key = Key> extends NodeJS.EventEmitter {
 		get(id: K): V | undefined


### PR DESCRIPTION
In #19 I swapped the order of the `K` and `V` generic arguments so that people would be able to define a value type without having to define a key type, but missed the swap in the top-level `open()` function.