### PR TITLE
Fix TypeScript definitions and add tests to test them

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,10 @@
+import { EventEmitter } from 'events'
+
 declare module 'lmdb-store' {
 	export function open<V = any, K extends Key = Key>(path: string, options: RootDatabaseOptions): RootDatabase<V, K>
 	export function open<V = any, K extends Key = Key>(options: RootDatabaseOptionsWithPath): RootDatabase<V, K>
 
-	class Database<V = any, K extends Key = Key> extends NodeJS.EventEmitter {
+	class Database<V = any, K extends Key = Key> extends EventEmitter {
 		get(id: K): V | undefined
 		getEntry(id: K): {
 			value: V | undefined

--- a/package.json
+++ b/package.json
@@ -21,11 +21,15 @@
     "require": "./index.js"
   },
   "types": "./index.d.ts",
+  "tsd": {
+    "directory": "test/types"
+  },
   "scripts": {
     "install": "node-gyp-build",
     "recompile": "node-gyp build",
-    "test": "./node_modules/.bin/mocha test/**.test.js --recursive",
+    "test": "./node_modules/.bin/mocha test/**.test.js --recursive && npm run test:types",
     "test2": "./node_modules/.bin/mocha tests -u tdd",
+    "test:types": "tsd",
     "benchmark": "node ./benchmark/index.js",
     "benchmark-ll": "node ./benchmark/low-level.js"
   },
@@ -46,6 +50,7 @@
     "mkdirp": "^1.0.4",
     "mocha": "^8.1.3",
     "node-gyp": "^7.1.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "tsd": "^0.13.1"
   }
 }

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,0 +1,14 @@
+import { expectType } from 'tsd'
+import { open, RootDatabase } from '../..'
+
+const path = 'type-test-store'
+
+expectType<RootDatabase>(open(path, { compression: true }))
+expectType<RootDatabase>(open({ path, compression: true }))
+
+const defaultStore = open({ path, compression: true })
+expectType<boolean>(await defaultStore.put('foo', { bar: 'baz' }))
+expectType<any>(defaultStore.get('foo'))
+
+const typedStore = open<string>({ path, compression: true })
+expectType<string | undefined>(typedStore.get('foo'))


### PR DESCRIPTION
Using this module in a project that uses `@types/node` together with Node.js 13 or newer, will generate this error:

```
./node_modules/lmdb-store/index.d.ts(5,55): error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?
```

This PR fixes that bug and adds test to ensure that the types are valid.

The types are tested using the [tsd](https://github.com/SamVerschueren/tsd) tool and you can run them locally using:

```
npm run test:types
```

Additionally I took the liberty to run them automatically after `npm test` so that they will be part of this projects CI - I hope you don't mind 😊