### PR TITLE
src/ordered-binary.cpp: correctly implement unshift on array keys

### DIFF
--- a/src/compression.cpp
+++ b/src/compression.cpp
@@ -1,3 +1,27 @@
+
+// This file is part of node-lmdb, the Node.js binding for lmdb
+// Copyright (c) 2013-2017 Timur Kristóf
+// Copyright (c) 2021 Kristopher Tate
+// Licensed to you under the terms of the MIT license
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 #include "lz4.h"
 #include "node-lmdb.h"
 
@@ -89,7 +113,7 @@ void Compression::decompress(MDB_val& data, bool &isValid) {
         dictionary, decompressTarget - dictionary);
     //fprintf(stdout, "first uncompressed byte %X %X %X %X %X %X\n", uncompressedData[0], uncompressedData[1], uncompressedData[2], uncompressedData[3], uncompressedData[4], uncompressedData[5]);
     if (written < 0) {
-        fprintf(stderr, "Failed to decompress data %u %u %u %u\n", charData[0], data.mv_size, compressionHeaderSize, uncompressedLength);
+        //fprintf(stderr, "Failed to decompress data %u %u %u %u\n", charData[0], data.mv_size, compressionHeaderSize, uncompressedLength);
         Nan::ThrowError("Failed to decompress data");
         isValid = false;
         return;
@@ -111,7 +135,7 @@ void Compression::expand(unsigned int size) {
 }
 
 argtokey_callback_t Compression::compress(MDB_val* value, argtokey_callback_t freeValue) {
-    int dataLength = value->mv_size;
+    size_t dataLength = value->mv_size;
     char* data = (char*)value->mv_data;
     if (value->mv_size < compressionThreshold && !(value->mv_size > 0 && ((uint8_t*)data)[0] >= 250))
         return freeValue; // don't compress if less than threshold (but we must compress if the first byte is the compression indicator)

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1,6 +1,7 @@
 
 // This file is part of node-lmdb, the Node.js binding for lmdb
 // Copyright (c) 2013-2017 Timur Kristóf
+// Copyright (c) 2021 Kristopher Tate
 // Licensed to you under the terms of the MIT license
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -262,7 +263,6 @@ NAN_METHOD(CursorWrap::getCurrentBoolean) {
 }
 
 NAN_METHOD(CursorWrap::getCurrentIsDatabase) {
-    int al = info.Length();
     CursorWrap* cw = Nan::ObjectWrap::Unwrap<CursorWrap>(info.This());
     int isDatabase = mdb_cursor_is_db(cw->cursor);
     return info.GetReturnValue().Set(Nan::New<Boolean>(isDatabase));
@@ -399,5 +399,5 @@ void CursorWrap::setupExports(Local<Object> exports) {
     cursorTpl->PrototypeTemplate()->Set(Nan::New<String>("del").ToLocalChecked(), Nan::New<FunctionTemplate>(CursorWrap::del));
 
     // Set exports
-    exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Cursor").ToLocalChecked(), cursorTpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
+    (void)exports->Set(Nan::GetCurrentContext(), Nan::New<String>("Cursor").ToLocalChecked(), cursorTpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }

--- a/src/dbi.cpp
+++ b/src/dbi.cpp
@@ -1,6 +1,7 @@
 
 // This file is part of node-lmdb, the Node.js binding for lmdb
 // Copyright (c) 2013-2017 Timur Kristóf
+// Copyright (c) 2021 Kristopher Tate
 // Licensed to you under the terms of the MIT license
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -61,7 +62,7 @@ DbiWrap::~DbiWrap() {
 
 void DbiWrap::setUnsafeBuffer(char* unsafePtr, const Persistent<Object> &unsafeBuffer) {
     if (lastUnsafePtr != unsafePtr) {
-        handle()->Set(Nan::GetCurrentContext(), Nan::New<String>("unsafeBuffer").ToLocalChecked(),
+        (void)handle()->Set(Nan::GetCurrentContext(), Nan::New<String>("unsafeBuffer").ToLocalChecked(),
             unsafeBuffer.Get(Isolate::GetCurrent()));
         lastUnsafePtr = unsafePtr;
     }
@@ -125,7 +126,7 @@ NAN_METHOD(DbiWrap::ctor) {
         if (create->IsBoolean() ? !create->BooleanValue(Isolate::GetCurrent()) : true) {
         #else
         if (create->IsBoolean() ? !create->BooleanValue(Nan::GetCurrentContext()).FromJust() : true) {
-        #endif;
+        #endif
             txnFlags |= MDB_RDONLY;
         }
         Local<Value> hasVersionsLocal = options->Get(Nan::GetCurrentContext(), Nan::New<String>("useVersions").ToLocalChecked()).ToLocalChecked();
@@ -232,7 +233,7 @@ NAN_METHOD(DbiWrap::drop) {
         del = opt->IsBoolean() ? !(opt->BooleanValue(Isolate::GetCurrent())) : 1;
         #else
         del = opt->IsBoolean() ? !(opt->BooleanValue(Nan::GetCurrentContext()).FromJust()) : 1;
-        #endif;
+        #endif
         
         // User-supplied txn
         auto txnObj = options->Get(Nan::GetCurrentContext(), Nan::New<String>("txn").ToLocalChecked()).ToLocalChecked();
@@ -292,12 +293,12 @@ NAN_METHOD(DbiWrap::stat) {
 
     Local<Context> context = Nan::GetCurrentContext();
     Local<Object> obj = Nan::New<Object>();
-    obj->Set(context, Nan::New<String>("pageSize").ToLocalChecked(), Nan::New<Number>(stat.ms_psize));
-    obj->Set(context, Nan::New<String>("treeDepth").ToLocalChecked(), Nan::New<Number>(stat.ms_depth));
-    obj->Set(context, Nan::New<String>("treeBranchPageCount").ToLocalChecked(), Nan::New<Number>(stat.ms_branch_pages));
-    obj->Set(context, Nan::New<String>("treeLeafPageCount").ToLocalChecked(), Nan::New<Number>(stat.ms_leaf_pages));
-    obj->Set(context, Nan::New<String>("entryCount").ToLocalChecked(), Nan::New<Number>(stat.ms_entries));
-    obj->Set(context, Nan::New<String>("overflowPages").ToLocalChecked(), Nan::New<Number>(stat.ms_overflow_pages));
+    (void)obj->Set(context, Nan::New<String>("pageSize").ToLocalChecked(), Nan::New<Number>(stat.ms_psize));
+    (void)obj->Set(context, Nan::New<String>("treeDepth").ToLocalChecked(), Nan::New<Number>(stat.ms_depth));
+    (void)obj->Set(context, Nan::New<String>("treeBranchPageCount").ToLocalChecked(), Nan::New<Number>(stat.ms_branch_pages));
+    (void)obj->Set(context, Nan::New<String>("treeLeafPageCount").ToLocalChecked(), Nan::New<Number>(stat.ms_leaf_pages));
+    (void)obj->Set(context, Nan::New<String>("entryCount").ToLocalChecked(), Nan::New<Number>(stat.ms_entries));
+    (void)obj->Set(context, Nan::New<String>("overflowPages").ToLocalChecked(), Nan::New<Number>(stat.ms_overflow_pages));
 
     info.GetReturnValue().Set(obj);
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,6 +1,7 @@
 
 // This file is part of node-lmdb, the Node.js binding for lmdb
 // Copyright (c) 2013-2017 Timur Kristóf
+// Copyright (c) 2021 Kristopher Tate
 // Licensed to you under the terms of the MIT license
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,12 +36,12 @@ void setupExportMisc(Local<Object> exports) {
     int major, minor, patch;
     char *str = mdb_version(&major, &minor, &patch);
     Local<Context> context = Nan::GetCurrentContext();
-    versionObj->Set(context, Nan::New<String>("versionString").ToLocalChecked(), Nan::New<String>(str).ToLocalChecked());
-    versionObj->Set(context, Nan::New<String>("major").ToLocalChecked(), Nan::New<Integer>(major));
-    versionObj->Set(context, Nan::New<String>("minor").ToLocalChecked(), Nan::New<Integer>(minor));
-    versionObj->Set(context, Nan::New<String>("patch").ToLocalChecked(), Nan::New<Integer>(patch));
+    (void)versionObj->Set(context, Nan::New<String>("versionString").ToLocalChecked(), Nan::New<String>(str).ToLocalChecked());
+    (void)versionObj->Set(context, Nan::New<String>("major").ToLocalChecked(), Nan::New<Integer>(major));
+    (void)versionObj->Set(context, Nan::New<String>("minor").ToLocalChecked(), Nan::New<Integer>(minor));
+    (void)versionObj->Set(context, Nan::New<String>("patch").ToLocalChecked(), Nan::New<Integer>(patch));
 
-    exports->Set(context, Nan::New<String>("version").ToLocalChecked(), versionObj);
+    (void)exports->Set(context, Nan::New<String>("version").ToLocalChecked(), versionObj);
     Nan::SetMethod(exports, "getLastVersion", getLastVersion);
     Nan::SetMethod(exports, "setLastVersion", setLastVersion);
     Nan::SetMethod(exports, "bufferToKeyValue", bufferToKeyValue);
@@ -57,7 +58,7 @@ void setFlagFromValue(int *flags, int flag, const char *name, bool defaultValue,
     if (opt->IsBoolean() ? opt->BooleanValue(Isolate::GetCurrent()) : defaultValue) {
     #else
     if (opt->IsBoolean() ? opt->BooleanValue(context).FromJust() : defaultValue) {
-    #endif;
+    #endif
         *flags |= flag;
     }
 }
@@ -333,7 +334,7 @@ NAN_METHOD(setLastVersion) {
 
 void throwLmdbError(int rc) {
     auto err = Nan::Error(mdb_strerror(rc));
-    err.As<Object>()->Set(Nan::GetCurrentContext(), Nan::New("code").ToLocalChecked(), Nan::New(rc));
+    (void)err.As<Object>()->Set(Nan::GetCurrentContext(), Nan::New("code").ToLocalChecked(), Nan::New(rc));
     return Nan::ThrowError(err);
 }
 

--- a/src/ordered-binary.cpp
+++ b/src/ordered-binary.cpp
@@ -264,11 +264,11 @@ Local<Value> MDBKeyToValue(MDB_val &val) {
         v8::Local<v8::Array> resultsArray;
         Local<Context> context = Nan::GetCurrentContext();
         if (nextValue->IsArray()) {
-            // unshift
-            resultsArray = Local<Array>::Cast(nextValue);
-            int length = resultsArray->Length();
+            v8::Local<v8::Array> nextArray = Local<Array>::Cast(nextValue);
+            int length = nextArray->Length();
+            resultsArray = Nan::New<v8::Array>(1 + length);
             for (int i = 0; i < length; i++) {
-                (void)resultsArray->Set(context, i + 1, resultsArray->Get(context, i).ToLocalChecked());
+                (void)resultsArray->Set(context, i + 1, nextArray->Get(context, i).ToLocalChecked());
             }
         } else {
             resultsArray = Nan::New<v8::Array>(2);

--- a/src/txn.cpp
+++ b/src/txn.cpp
@@ -1,6 +1,7 @@
 
 // This file is part of node-lmdb, the Node.js binding for lmdb
 // Copyright (c) 2013-2017 Timur Kristóf
+// Copyright (c) 2021 Kristopher Tate
 // Licensed to you under the terms of the MIT license
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -298,10 +299,10 @@ NAN_METHOD(TxnWrap::getRange) {
                 mdb_cmp(tw->txn, dw->dbi, &key, &endKey) <= 0 :
                 mdb_cmp(tw->txn, dw->dbi, &key, &endKey) >= 0)))) {
         if (getKeys) {
-            resultsArray->Set(context, resultsIndex++, valToUtf8(key));
+            (void)resultsArray->Set(context, resultsIndex++, valToUtf8(key));
         }
         if (getValues) {
-            resultsArray->Set(context, resultsIndex++, valToUtf8(data));
+            (void)resultsArray->Set(context, resultsIndex++, valToUtf8(data));
         }
         if (retrieved++ >= limit)
             break;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,6 +86,7 @@ describe('lmdb-store', function() {
         'hello',
         ['hello', 3],
         ['hello', 'world'],
+        [ 'uid', 'I-7l9ySkD-wAOULIjOEnb', 'Rwsu6gqOw8cqdCZG5_YNF' ],
         'z'
       ]
       for (let key of keys)


### PR DESCRIPTION
Thank-you for this library.

This PR fixes a bug inside of the `src/ordered-binary.cpp` implementation as well as various warnings.

Also, while reviewing the library, I noticed this destructor in `env.cpp` on line 223:

```cpp
    ~BatchWorker() {
        for (int i = 0; i < actionCount; i++) {
            action_t* action = &actions[i];
        }
        delete[] actions;
        delete keySpace;
    }
```

Perhaps someone could shed some light on why it is iterating through actions.

Thanks again!

