### PR TITLE
src/cursor.cpp: throw on call to closed cursor;

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -92,6 +92,9 @@ NAN_METHOD(CursorWrap::close) {
     Nan::HandleScope scope;
 
     CursorWrap *cw = Nan::ObjectWrap::Unwrap<CursorWrap>(info.This());
+    if (!cw->cursor) {
+      return Nan::ThrowError("cursor.close: Attempt to close a closed cursor!");
+    }
     mdb_cursor_close(cw->cursor);
     cw->dw->Unref();
     cw->tw->Unref();


### PR DESCRIPTION
Although `index.js` wraps cursor.cpp, this patch throws an error if a cursor generator is used incorrectly as it could lead to a segfault/assert. Thanks.